### PR TITLE
small fix to response from forageapi/routes/support.js

### DIFF
--- a/forageapi/routes/support.js
+++ b/forageapi/routes/support.js
@@ -64,7 +64,9 @@ router.post("/", async (req, res, next) => {
       .insertOne(req.body)
       .then((result) => {
         res.status(200);
-        res.send(`Support item created`);
+        // res.send(`Support item created`);
+        // added this in to send person back to home page
+        res.redirect("/");
       })
       .catch((error) => {
         res.send(error.message);


### PR DESCRIPTION
Small change in the forageapi support folder, has it, after logging the info, send a redirect to the main page as opposed to sending response data.  So after you submit the form, it goes to the home page... with an easy to find alert response.